### PR TITLE
pref('enforce_login') redirects to $requested_path.login rather than /.lo

### DIFF
--- a/lib/MojoMojo/Controller/Root.pm
+++ b/lib/MojoMojo/Controller/Root.pm
@@ -123,7 +123,11 @@ sub auto : Private {
             return 1;
         }
         if ( !$c->user_exists ) {
-            $c->res->redirect( $c->uri_for('/.login') );
+                $c->res->redirect(
+                        $c->uri_for(     
+                                $c->stash->{path} . '.login' # send them to the login for this page
+                        )
+                );
         }
     }
 


### PR DESCRIPTION
pref('enforce_login') redirects to $requested_path.login rather than /.login
