### PR TITLE
Pod::Simple compliance

### DIFF
--- a/lib/MojoMojo/Controller/Tag.pm
+++ b/lib/MojoMojo/Controller/Tag.pm
@@ -25,7 +25,7 @@ tagged with a given tag.
 =head2 list
 
 This is a private action, and is dispatched from
-L</.list|MojoMojo::Controller::Page/list> when supplied with a tag
+L<E<47>.list|MojoMojo::Controller::Page/list> when supplied with a tag
 argument. It will list all pages tagged with the given tag.
 
 =cut
@@ -44,7 +44,7 @@ sub list : Private {
 =head2 recent
 
 This is a private action, and is dispatched from
-L</.recent|MojoMojo::Controller::Page/recent> when supplied with a tag
+L<E<47>.recent|MojoMojo::Controller::Page/recent> when supplied with a tag
 argument. It will list recent pages tagged with the given tag.
 
 =cut

--- a/lib/MojoMojo/Declaw.pm
+++ b/lib/MojoMojo/Declaw.pm
@@ -825,15 +825,15 @@ If $Defang->{tags_callback} exists, and HTML::Declaw has parsed a tag preset in 
 
 =over 4
 
-=item 0
+=item I<0>
 
 The current tag will not be defanged.
 
-=item 1
+=item I<1>
 
 The current tag will be defanged.
 
-=item 2
+=item I<2>
 
 The current tag will be processed normally by HTML:Defang as if there was no callback method specified.
 
@@ -867,15 +867,15 @@ See $AttributeHash for details of decoding.
 
 =over 4
 
-=item 0
+=item I<0>
 
 The current attribute will not be defanged.
 
-=item 1
+=item I<1>
 
 The current attribute will be defanged.
 
-=item 2
+=item I<2>
 
 The current attribute will be processed normally by HTML:Defang as if there was no callback method specified.
 
@@ -912,15 +912,15 @@ rather than just a scalar value. You can add attributes (remember to make it a s
 
 =over 4
 
-=item 0
+=item I<0>
 
 The current URL will not be defanged.
 
-=item 1
+=item I<1>
 
 The current URL will be defanged.
 
-=item 2
+=item I<2>
 
 The current URL will be processed normally by HTML:Defang as if there was no callback method specified.
 

--- a/lib/MojoMojo/Formatter/WikipediaLink.pm
+++ b/lib/MojoMojo/Formatter/WikipediaLink.pm
@@ -4,6 +4,8 @@ use warnings;
 use parent qw/MojoMojo::Formatter/;
 use utf8;
 
+=encoding utf8
+
 =head1 NAME
 
 MojoMojo::Formatter::WikipediaLink - Linked Wikipedia by writing {{wikipedia:<lang> <word>}}


### PR DESCRIPTION
Recent Pod::Simple development has brought us plenty new warning which are then translated to failing test t/02pod.t

I've patched the pod of three modules to get Pod::Simple of perl 5.18-RC0 silent.
- encoding utf8
- unescaped slash
- =item followed by number

Enjoy,
