### PR TITLE
Splitting the initial '(?' is deprecated in regex

### DIFF
--- a/lib/MojoMojo/Formatter/Wiki.pm
+++ b/lib/MojoMojo/Formatter/Wiki.pm
@@ -83,7 +83,7 @@ sub _generate_non_wikiword_check {
     # but why the question mark ('\?') at the end?
     my $non_wikiword_chars =
         ( join '', _explicit_start_delims() ) . $wikiword_escape . '\/' . '\?';
-    return qr{( ?<! [$non_wikiword_chars] )}x;
+    return qr{(?<! [$non_wikiword_chars])}x;
 }
 
 my $non_wikiword_check = _generate_non_wikiword_check();


### PR DESCRIPTION
This is a minor fix to regex syntax to suppress warnings on current perl versions
