### PR TITLE
Name test databases with process ID for parallelism

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Makefile.old
 *META.yml
 pm_to_blib
 t/var/mojomojo.db
+t/var/mojomojo-*.db
 t/var/mojomojo.yml
 t/var/uploads
 mojomojos.kpf

--- a/t/lib/MojoMojoTestSchema.pm
+++ b/t/lib/MojoMojoTestSchema.pm
@@ -15,8 +15,7 @@ my $attrs = {
     no_comments => 1
 };
 my $db_dir = 't/var';
-my $db_file = "$db_dir/mojomojo.db";
-
+my $db_file = "$db_dir/mojomojo-$$.db";
 
 =head1 NAME
 


### PR DESCRIPTION
This change allows the t/t/schema_DBIC*.t tests to be run in parallel by
using the process ID in the temporary database file name.

The original tests have some code for tidying up the temporary files but
it's all commented out, so I just added the appropriate .gitignore entry
to ignore the temporary files and left it at that.