### PR TITLE
Unbreak unicode.t with newer Catalyst versions

### DIFF
--- a/t/lib/MojoMojoTestSchema.pm
+++ b/t/lib/MojoMojoTestSchema.pm
@@ -124,6 +124,7 @@ sub init_schema {
             view_allowed             => 1,
             attachment_allowed       => 0,
         },
+        'encoding' => undef,
         'View::Email' => { sender => { mailer => 'Test' } },
         'system_mail' => 'admin@localhost',
     };


### PR DESCRIPTION
From Catalyst-5.90079_001 Changes:

- !!! UTF-8 is now the default encoding (there used to be none...).
  You can disable this if you need to with MyApp->config(encoding =>
  undef) if it causes you trouble.

This breaks unicode.t tests 7-8. Explicitly unset the encoding
as a fix/workaround.

Bug-Debian: https://bugs.debian.org/791520