### PR TITLE
spelling fixes

### DIFF
--- a/lib/MojoMojo/Declaw.pm
+++ b/lib/MojoMojo/Declaw.pm
@@ -25,8 +25,8 @@ Derived from HTML::Defang version 1.01.
   # Callback for custom handling specific HTML tags
   sub DefangTagsCallback {
     my ($Self, $Defang, $OpenAngle, $lcTag, $IsEndTag, $AttributeHash, $CloseAngle, $HtmlR, $OutR) = @_;
-    return 1 if $lcTag eq 'br';    # Explicitly defang this tag, eventhough safe
-    return 0 if $lcTag eq 'embed'; # Explicitly whitelist this tag, eventhough unsafe
+    return 1 if $lcTag eq 'br';    # Explicitly defang this tag, even though safe
+    return 0 if $lcTag eq 'embed'; # Explicitly whitelist this tag, even though unsafe
     return 2 if $lcTag eq 'img';   # I am not sure what to do with this tag, so process as HTML::Defang normally would
   }
 
@@ -1427,7 +1427,7 @@ Any space after the tag, but before attributes.
 
 =item I<$Attributes>
 
-A reference to an array of the attributes and their values, including any surrouding spaces. Each element of the array is added by 'push' calls like below.
+A reference to an array of the attributes and their values, including any surrounding spaces. Each element of the array is added by 'push' calls like below.
 
   push @$Attributes, [ $AttributeName, $SpaceBeforeEquals, $EqualsAndSubsequentSpace, $QuoteChar, $AttributeValue, $QuoteChar, $SpaceAfterAtributeValue ];
 
@@ -2261,7 +2261,7 @@ Kurian Jose Aerthail E<lt>cpan@kurianja.fastmail.fmE<gt>. Thanks to Rob Mueller 
 
 =head1 COPYRIGHT AND LICENSE
 
-HTML::Declaw is a modifed version of HTML::Defang which has the following license:
+HTML::Declaw is a modified version of HTML::Defang which has the following license:
 
 Copyright (C) 2003-2009 by The FastMail Partnership
 

--- a/lib/MojoMojo/Formatter/Amazon.pm
+++ b/lib/MojoMojo/Formatter/Amazon.pm
@@ -25,7 +25,7 @@ This is an url formatter. it takes urls containing amazon and
 in the amazon web store.
 
 It automatically handles books/movies/dvds and formats them as
-apropriate. You can also pass 'small' as a parameter after the
+appropriate. You can also pass 'small' as a parameter after the
 url, and it will make a thumb link instead of a blurb.
 
 =head1 METHODS

--- a/lib/MojoMojo/View/TT.pm
+++ b/lib/MojoMojo/View/TT.pm
@@ -32,7 +32,7 @@ __PACKAGE__->config->{FILTERS}            = { nav => [ \&_nav_filter, 1 ] };
 
 =head2 new
 
-Contructor for TT View.  Can configure paths to .tt files here.
+Constructor for TT View.  Can configure paths to .tt files here.
 
 =cut
 

--- a/script/mojomojo_update_db.pl
+++ b/script/mojomojo_update_db.pl
@@ -10,7 +10,7 @@ dab
 
 =head1 DESCRIPTION
 
-DBIx Versionning see on catapulse.org http://www.catapulse.org/articles/view/75
+DBIx Versioning see on catapulse.org http://www.catapulse.org/articles/view/75
 
 =cut
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to MojoMojo.
We thought you might be interested in it too.

    Description: spelling fixes
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-01-13
    

The patch is tracked in our Git repository at
https://anonscm.debian.org/cgit/pkg-perl/packages/libmojomojo-perl.git/plain/debian/patches/spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
