### PR TITLE
Use Config::ZOMG

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -33,7 +33,7 @@ requires(
     'Catalyst::View::Email'                        => '0.14',
     'Catalyst::View::Email::Template'              => 0,
     'Config::General'                              => 0,
-    'Config::JFDI'                                 => 0,
+    'Config::ZOMG'                                 => 0,
     'Crypt::CBC'                                   => '2.12',     # FormFu
     'Data::Page'                                   => '2.00',
     'DateTime'                                     => '0.28',

--- a/script/mojomojo_spawn_db.pl
+++ b/script/mojomojo_spawn_db.pl
@@ -24,7 +24,7 @@ use Config::ZOMG;
 use Getopt::Long;
 
 my $jfdi   = Config::ZOMG->new(name => "MojoMojo");
-my $config = $jfdi->get;
+my $config = $jfdi->load;
 
 my ($dsn, $user, $password, $unicode_option);
 

--- a/script/mojomojo_spawn_db.pl
+++ b/script/mojomojo_spawn_db.pl
@@ -20,10 +20,10 @@ use warnings;
 use FindBin '$Bin';
 use lib "$Bin/../lib";
 use MojoMojo::Schema;
-use Config::JFDI;
+use Config::ZOMG;
 use Getopt::Long;
 
-my $jfdi   = Config::JFDI->new(name => "MojoMojo");
+my $jfdi   = Config::ZOMG->new(name => "MojoMojo");
 my $config = $jfdi->get;
 
 my ($dsn, $user, $password, $unicode_option);

--- a/script/mojomojo_update_db.pl
+++ b/script/mojomojo_update_db.pl
@@ -19,10 +19,10 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../lib";
 use MojoMojo::Schema;
-use Config::JFDI;
+use Config::ZOMG;
 use Term::Prompt;
 
-my $jfdi = Config::JFDI->new(name => "MojoMojo");
+my $jfdi = Config::ZOMG->new(name => "MojoMojo");
 my $config = $jfdi->get;
 
 my ($dsn, $user, $pass) = @ARGV;

--- a/script/mojomojo_update_db.pl
+++ b/script/mojomojo_update_db.pl
@@ -23,7 +23,7 @@ use Config::ZOMG;
 use Term::Prompt;
 
 my $jfdi = Config::ZOMG->new(name => "MojoMojo");
-my $config = $jfdi->get;
+my $config = $jfdi->load;
 
 my ($dsn, $user, $pass) = @ARGV;
 eval {

--- a/script/util/bust_cache.pl
+++ b/script/util/bust_cache.pl
@@ -41,7 +41,7 @@ if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
     require Config::ZOMG;
     
-    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->load;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {

--- a/script/util/bust_cache.pl
+++ b/script/util/bust_cache.pl
@@ -39,9 +39,9 @@ will recompile the page next time it is requested.
 
 if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
-    require Config::JFDI;
+    require Config::ZOMG;
     
-    my $config = Config::JFDI->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {

--- a/script/util/delete_page.pl
+++ b/script/util/delete_page.pl
@@ -8,9 +8,9 @@ use warnings;
 use FindBin;
 use lib "$FindBin::Bin/../../lib";
 use MojoMojo::Schema;
-use Config::JFDI;
+use Config::ZOMG;
 use Term::Prompt;
-my $jfdi = Config::JFDI->new(name => "MojoMojo");
+my $jfdi = Config::ZOMG->new(name => "MojoMojo");
 my $config = $jfdi->get;
 my ($dsn, $user, $pass) = @ARGV;
 eval {

--- a/script/util/delete_page.pl
+++ b/script/util/delete_page.pl
@@ -11,7 +11,7 @@ use MojoMojo::Schema;
 use Config::ZOMG;
 use Term::Prompt;
 my $jfdi = Config::ZOMG->new(name => "MojoMojo");
-my $config = $jfdi->get;
+my $config = $jfdi->load;
 my ($dsn, $user, $pass) = @ARGV;
 eval {
     if (!$dsn) {

--- a/script/util/dir2mojomojo.pl
+++ b/script/util/dir2mojomojo.pl
@@ -38,7 +38,7 @@ $DIR =~ s/~/$ENV{HOME}/;
 # Connect to database
 #-----------------------------------------------------------------------------#
 my $jfdi = Config::ZOMG->new(name => "MojoMojo");
-my $config = $jfdi->get;
+my $config = $jfdi->load;
 
 my ($dsn, $user, $pass) = @ARGV;
 eval {

--- a/script/util/dir2mojomojo.pl
+++ b/script/util/dir2mojomojo.pl
@@ -6,7 +6,7 @@ use warnings;
 use FindBin '$Bin';
 use lib "$Bin/../../lib";
 use MojoMojo::Schema;
-use Config::JFDI;
+use Config::ZOMG;
 use MojoMojo::Formatter::File;
 use Path::Class ();
 use Getopt::Long;
@@ -37,7 +37,7 @@ $DIR =~ s/~/$ENV{HOME}/;
 #-----------------------------------------------------------------------------#
 # Connect to database
 #-----------------------------------------------------------------------------#
-my $jfdi = Config::JFDI->new(name => "MojoMojo");
+my $jfdi = Config::ZOMG->new(name => "MojoMojo");
 my $config = $jfdi->get;
 
 my ($dsn, $user, $pass) = @ARGV;

--- a/script/util/dump_content.pl
+++ b/script/util/dump_content.pl
@@ -37,9 +37,9 @@ Dump the raw (markup) contents of the last version of a page.
 
 if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
-    require Config::JFDI;
+    require Config::ZOMG;
     
-    my $config = Config::JFDI->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {

--- a/script/util/dump_content.pl
+++ b/script/util/dump_content.pl
@@ -39,7 +39,7 @@ if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
     require Config::ZOMG;
     
-    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->load;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {

--- a/script/util/import_content.pl
+++ b/script/util/import_content.pl
@@ -82,9 +82,9 @@ Replace the contents of the last version of a page with the content from a file.
 
 if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
-    require Config::JFDI;
+    require Config::ZOMG;
     
-    my $config = Config::JFDI->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {

--- a/script/util/import_content.pl
+++ b/script/util/import_content.pl
@@ -84,7 +84,7 @@ if (!$dsn) {
     # no DSN passed via the command line; attempting to read one from the config file
     require Config::ZOMG;
     
-    my $config = Config::ZOMG->new(name => "MojoMojo")->get;
+    my $config = Config::ZOMG->new(name => "MojoMojo")->load;
     die "Couldn't read config file" if not keys %{$config};
     
     eval {


### PR DESCRIPTION
Config::JDFI does not appear to be maintained any longer and it's reliance on Any::Moose causes a warning to STDERR. Switching to Config::ZOMG is an easy work around.

I haven't create a test for this patch. It didn't seem necessary.